### PR TITLE
Automatically delete old cron job logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.1.0
+====
+
+* (feature) Introduced Bundleconfiguration to set the Duration when old cron job logs should be deleted.
+
+
 2.0.2
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 2.1.0
 ====
 
-* (feature) Introduced Bundleconfiguration to set the Duration when old cron job logs should be deleted.
+*   (feature) Automatically delete old cron job logs.
 
 
 2.0.2

--- a/src/Cron/CronJobCleanUp.php
+++ b/src/Cron/CronJobCleanUp.php
@@ -55,11 +55,10 @@ class CronJobCleanUp implements CronJobInterface
     public function execute (BufferedSymfonyStyle $io) : CronStatus
     {
         try {
-            $success = $this->cronModel->removeOldLogsByLogTtl($this->logTtl);
+            $this->cronModel->removeOldLogsByLogTtl($this->logTtl);
+            return new CronStatus(true, $io->getBuffer());
         } catch (\Exception $e) {
-            $success = false;
+            return new CronStatus(false, $io->getBuffer());
         }
-
-        return new CronStatus($success, $io->getBuffer());
     }
 }

--- a/src/Cron/CronJobCleanUp.php
+++ b/src/Cron/CronJobCleanUp.php
@@ -16,18 +16,18 @@ class CronJobCleanUp implements CronJobInterface
     /** @var CronModel $cronModel */
     private $cronModel;
 
-    /** @var int $storageDuration */
-    private $storageDuration;
+    /** @var int $logTtl */
+    private $logTtl;
 
 
     public function __construct
     (
         CronModel $cronModel,
-        int $storageDuration
+        int $logTtl
     )
     {
         $this->cronModel = $cronModel;
-        $this->storageDuration = $storageDuration;
+        $this->logTtl = $logTtl;
     }
 
 
@@ -54,7 +54,11 @@ class CronJobCleanUp implements CronJobInterface
      */
     public function execute (BufferedSymfonyStyle $io) : CronStatus
     {
-        $success = $this->cronModel->removeOldLogsByStorageDuration($this->storageDuration);
+        try {
+            $success = $this->cronModel->removeOldLogsByLogTtl($this->logTtl);
+        } catch (\Exception $e) {
+            $success = false;
+        }
 
         return new CronStatus($success, $io->getBuffer());
     }

--- a/src/Cron/CronJobCleanUp.php
+++ b/src/Cron/CronJobCleanUp.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+
+namespace Becklyn\CronJobBundle\Cron;
+
+use Becklyn\CronJobBundle\Console\BufferedSymfonyStyle;
+use Becklyn\CronJobBundle\Data\CronStatus;
+use Becklyn\CronJobBundle\Model\CronModel;
+
+/**
+ * @author Marco Woehr <mw@becklyn.com>
+ * @since 2021-09-23
+ */
+class CronJobCleanUp implements CronJobInterface
+{
+    /** @var CronModel $cronModel */
+    private $cronModel;
+
+    /** @var int $storageDuration */
+    private $storageDuration;
+
+
+    public function __construct
+    (
+        CronModel $cronModel,
+        int $storageDuration
+    )
+    {
+        $this->cronModel = $cronModel;
+        $this->storageDuration = $storageDuration;
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function getCronTab () : string
+    {
+        return "@daily";
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function getName () : string
+    {
+        return "cron:cleanup:logs";
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function execute (BufferedSymfonyStyle $io) : CronStatus
+    {
+        $success = $this->cronModel->removeOldLogsByStorageDuration($this->storageDuration);
+
+        return new CronStatus($success, $io->getBuffer());
+    }
+}

--- a/src/CronJobBundle.php
+++ b/src/CronJobBundle.php
@@ -2,6 +2,7 @@
 
 namespace Becklyn\CronJobBundle;
 
+use Becklyn\CronJobBundle\Cron\CronJobCleanUp;
 use Becklyn\CronJobBundle\Cron\CronJobInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -36,13 +37,21 @@ class CronJobBundle extends Bundle
                 // load main services.yml
                 $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Resources/config'));
                 $loader->load('services.yaml');
+
+                $config = $this->processConfiguration(
+                    new CronJobBundleConfiguration(),
+                    $configs
+                );
+
+                $container->getDefinition(CronJobCleanUp::class)
+                    ->setArgument('$storageDuration', $config["storage_duration"]);
             }
 
 
             /**
              * @inheritDoc
              */
-            public function getAlias ()
+            public function getAlias () : string
             {
                 return "becklyn_cron_job";
             }

--- a/src/CronJobBundle.php
+++ b/src/CronJobBundle.php
@@ -44,7 +44,7 @@ class CronJobBundle extends Bundle
                 );
 
                 $container->getDefinition(CronJobCleanUp::class)
-                    ->setArgument('$storageDuration', $config["storage_duration"]);
+                    ->setArgument('$logTtl', $config["log_ttl"]);
             }
 
 

--- a/src/DependencyInjection/CronJobBundleConfiguration.php
+++ b/src/DependencyInjection/CronJobBundleConfiguration.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+
+namespace Becklyn\CronJobBundle;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Marco Woehr <mw@becklyn.com>
+ * @since 2021-09-23
+ */
+class CronJobBundleConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder () : TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder("becklyn_cron_job");
+
+        $treeBuilder->getRootNode()
+                ->children()
+                ->integerNode("storage_duration")
+                ->defaultValue(30)
+                ->info("The Duration how long a Cron Job Log will be stored in the Database before it get's deleted in Days.")
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/CronJobBundleConfiguration.php
+++ b/src/DependencyInjection/CronJobBundleConfiguration.php
@@ -18,9 +18,9 @@ class CronJobBundleConfiguration implements ConfigurationInterface
 
         $treeBuilder->getRootNode()
                 ->children()
-                ->integerNode("storage_duration")
+                ->integerNode("log_ttl")
                 ->defaultValue(30)
-                ->info("The Duration how long a Cron Job Log will be stored in the Database before it get's deleted in Days.")
+                ->info("The ttl of a cron job log entry in days.")
                 ->end()
             ->end();
 

--- a/src/Model/CronModel.php
+++ b/src/Model/CronModel.php
@@ -62,7 +62,7 @@ class CronModel
     }
 
 
-    public function removeOldLogsByLogTtl (int $logTtl) : bool
+    public function removeOldLogsByLogTtl (int $logTtl) : void
     {
         $this->entityManager->createQueryBuilder()
             ->delete(CronJobRun::class, "job")

--- a/src/Model/CronModel.php
+++ b/src/Model/CronModel.php
@@ -62,6 +62,25 @@ class CronModel
     }
 
 
+    public function removeOldLogsByStorageDuration (int $storageDuration) : bool
+    {
+        $compareDate = new \DateTimeImmutable("- {$storageDuration} days");
+
+        try {
+            $this->entityManager->createQueryBuilder()
+                ->delete(CronJobRun::class, "job")
+                ->where("job.timeRun < :storageDuration")
+                ->setParameter("storageDuration", $compareDate)
+                ->getQuery()
+                ->execute();
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+
     /**
      */
     public function logRun (WrappedJob $job, CronStatus $status) : void

--- a/src/Model/CronModel.php
+++ b/src/Model/CronModel.php
@@ -62,22 +62,14 @@ class CronModel
     }
 
 
-    public function removeOldLogsByStorageDuration (int $storageDuration) : bool
+    public function removeOldLogsByLogTtl (int $logTtl) : bool
     {
-        $compareDate = new \DateTimeImmutable("- {$storageDuration} days");
-
-        try {
-            $this->entityManager->createQueryBuilder()
-                ->delete(CronJobRun::class, "job")
-                ->where("job.timeRun < :storageDuration")
-                ->setParameter("storageDuration", $compareDate)
-                ->getQuery()
-                ->execute();
-        } catch (\Exception $e) {
-            return false;
-        }
-
-        return true;
+        $this->entityManager->createQueryBuilder()
+            ->delete(CronJobRun::class, "job")
+            ->where("job.timeRun < :logTtl")
+            ->setParameter("logTtl", new \DateTimeImmutable("- {$logTtl} days"))
+            ->getQuery()
+            ->execute();
     }
 
 


### PR DESCRIPTION
… when old job logs should be deleted from the database.

| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  | yes/!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      |no                                                                |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
Added Bundle configuration to set the duration in days when old job logs should be deleted from the database. Default : 30 Days

**becklyn_cron_job.yaml**:

> becklyn_cron_job:
  >           storage_duration: 30
> 