### PR TITLE
Add new column "error_count"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.1.3
+====
+
+*   (feature) Add column `error_count`.
+
 2.1.2
 ====
 

--- a/src/Data/CronStatus.php
+++ b/src/Data/CronStatus.php
@@ -15,13 +15,19 @@ class CronStatus
      */
     private $log;
 
+    /**
+     * @var int
+     */
+    private $errorCount;
+
 
     /**
      */
-    public function __construct (bool $succeeded, ?string $log = null)
+    public function __construct (bool $succeeded, ?string $log = null, ?int $errorCount = null)
     {
         $this->succeeded = $succeeded;
         $this->log = $log;
+        $this->errorCount = $errorCount;
     }
 
 
@@ -38,5 +44,10 @@ class CronStatus
     public function getLog () : ?string
     {
         return $this->log;
+    }
+
+    public function getErrorCount () : ?int
+    {
+        return $this->errorCount;
     }
 }

--- a/src/Entity/CronJobRun.php
+++ b/src/Entity/CronJobRun.php
@@ -53,14 +53,20 @@ class CronJobRun
      */
     private $timeRun;
 
+    /**
+     * @var int|null
+     * @ORM\Column(name="error_count", type="integer", nullable=true)
+     */
+    private $errorCount;
 
     /**
      */
-    public function __construct (string $jobKey, bool $successful, ?string $log, \DateTimeImmutable $timeRun)
+    public function __construct (string $jobKey, bool $successful, ?string $log, ?int $errorCount, \DateTimeImmutable $timeRun)
     {
         $this->jobKey = $jobKey;
         $this->successful = $successful;
         $this->log = $log;
+        $this->errorCount = $errorCount;
         $this->timeRun = $timeRun;
     }
 
@@ -104,4 +110,10 @@ class CronJobRun
     {
         return $this->timeRun;
     }
+
+    public function getErrorCount(): ?int
+    {
+        return $this->errorCount;
+    }
+
 }

--- a/src/Model/CronModel.php
+++ b/src/Model/CronModel.php
@@ -81,6 +81,7 @@ class CronModel
             $job->getKey(),
             $status->isSucceeded(),
             $status->getLog(),
+            $status->getErrorCount(),
             $job->getSupposedLastRun()
         );
 

--- a/tests/JobTestTrait.php
+++ b/tests/JobTestTrait.php
@@ -76,8 +76,8 @@ trait JobTestTrait
      *
      * @return CronJobRun
      */
-    private function createCronJobRun (string $date, bool $successful = true, ?string $log = null) : CronJobRun
+    private function createCronJobRun (string $date, bool $successful = true, ?string $log = null, ?int $errorCount = null) : CronJobRun
     {
-        return new CronJobRun("test", $successful, $log, $this->createDateTime($date));
+        return new CronJobRun("test", $successful, $log, $errorCount, $this->createDateTime($date));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | yes                   |
| Improvement?  | no     |
| Bug fix?      | no                                                                |
| Deprecations? | no   |
| Docs PR       | missing                                |

Add a new column "error_count" to the table. It can be useful to detect when a job needs to process a list of data in a loop and one or more of them fails, but not the entire process.
